### PR TITLE
FIX bug when skipping adjustment of allowance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-cli",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "description": "CLI interface for using the nahmii by hubii protocol",
   "main": "index.js",
   "scripts": {

--- a/src/commands/claim-nii.js
+++ b/src/commands/claim-nii.js
@@ -123,6 +123,9 @@ function validatePeriod(period) {
 }
 
 function reduceReceipt(txReceipt) {
+    if (!txReceipt)
+        return null;
+
     // TODO: Fix links when on mainnet
     return {
         transactionHash: txReceipt.transactionHash,


### PR DESCRIPTION
Claiming tokens with a preset allowance will skip some steps. This PR fixes the issue that caused with output reporting.