### PR TITLE
Deprecate keythereum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-cli",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "CLI interface for using the nahmii by hubii protocol",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,6 @@
     "bson": "1.1.1",
     "ethers": "^4.0.37",
     "js-yaml": "^3.13.1",
-    "keythereum": "^1.0.4",
     "nahmii-contract-abstractions": "2.1.4",
     "nahmii-contract-abstractions-ropsten": "3.1.6",
     "nahmii-ethereum-address": "^2.1.0",

--- a/src/commands/claim-nii.js
+++ b/src/commands/claim-nii.js
@@ -38,7 +38,8 @@ module.exports = {
 
         const config = require('../config');
         const provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
-        const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+        const privateKey = await config.privateKey(config.wallet.secret);
+        const wallet = new nahmii.Wallet(privateKey, provider);
         const niiContract = await nahmii.Erc20Contract.from('NII', wallet);
 
         const spinner = ora();

--- a/src/commands/claim-nii.spec.js
+++ b/src/commands/claim-nii.spec.js
@@ -119,7 +119,7 @@ describe('Claim NII command', () => {
     beforeEach(() => {
         stubbedConfig.privateKey
             .withArgs(stubbedConfig.wallet.secret)
-            .returns('privatekey');
+            .resolves('privatekey');
         fakeNahmiiProvider.from
             .withArgs(stubbedConfig.apiRoot, stubbedConfig.appId, stubbedConfig.appSecret)
             .resolves(stubbedProviderInstance);

--- a/src/commands/deposit.js
+++ b/src/commands/deposit.js
@@ -35,7 +35,8 @@ module.exports = {
 
         const config = require('../config');
         const provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
-        const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+        const privateKey = await config.privateKey(config.wallet.secret);
+        const wallet = new nahmii.Wallet(privateKey, provider);
 
         const spinner = ora();
         try {

--- a/src/commands/deposit.spec.js
+++ b/src/commands/deposit.spec.js
@@ -81,7 +81,7 @@ describe('Deposit command', () => {
     beforeEach(() => {
         stubbedConfig.privateKey
             .withArgs(stubbedConfig.wallet.secret)
-            .returns('privatekey');
+            .resolves('privatekey');
         fakeNahmiiProvider.from
             .withArgs(stubbedConfig.apiRoot, stubbedConfig.appId, stubbedConfig.appSecret)
             .resolves(stubbedProviderInstance);

--- a/src/commands/pay.js
+++ b/src/commands/pay.js
@@ -12,7 +12,8 @@ module.exports = {
     handler: async (argv) => {
         const config = require('../config');
         const provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
-        const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+        const privateKey = await config.privateKey(config.wallet.secret);
+        const wallet = new nahmii.Wallet(privateKey, provider);
 
         try {
             const currencyDefinition = await getCurrencyBySymbol(provider, argv.currency);

--- a/src/commands/pay.spec.js
+++ b/src/commands/pay.spec.js
@@ -122,7 +122,7 @@ describe('Pay command', () => {
                 .returns(fakePayment);
             stubbedConfig.privateKey
                 .withArgs(stubbedConfig.wallet.secret)
-                .returns(expectedPrivateKey);
+                .resolves(expectedPrivateKey);
             await cmd({
                 amount: '1000',
                 currency: 'HBT',
@@ -165,7 +165,7 @@ describe('Pay command', () => {
                 ).returns(fakePayment);
             stubbedConfig.privateKey
                 .withArgs(stubbedConfig.wallet.secret)
-                .returns(expectedPrivateKey);
+                .resolves(expectedPrivateKey);
             await cmd({
                 amount: '1.1',
                 currency: 'ETH',

--- a/src/commands/pay.spec.js
+++ b/src/commands/pay.spec.js
@@ -109,7 +109,7 @@ describe('Pay command', () => {
             stubbedMonetaryAmount.from
                 .withArgs(
                     ethers.utils.parseUnits('1000', testCurrency.hbt.decimals),
-                    testCurrency.hbt.currency,
+                    testCurrency.hbt.currency
                 )
                 .returns(fakeMoney);
             stubbedPayment

--- a/src/commands/settle.js
+++ b/src/commands/settle.js
@@ -41,7 +41,8 @@ module.exports = {
             const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));
 
             const stageMonetaryAmount = nahmii.MonetaryAmount.from(amount.toString(), tokenInfo.currency);
-            const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+            const privateKey = await config.privateKey(config.wallet.secret);
+            const wallet = new nahmii.Wallet(privateKey, provider);
             const settlement = new nahmii.SettlementFactory(provider);
             const balances = await wallet.getNahmiiBalance();
             const balance = balances[currency];

--- a/src/commands/settle.spec.js
+++ b/src/commands/settle.spec.js
@@ -119,7 +119,7 @@ describe('settle command', () => {
     beforeEach(() => {
         stubbedConfig.privateKey
             .withArgs(stubbedConfig.wallet.secret)
-            .returns('privatekey');
+            .resolves('privatekey');
         fakeNahmiiProvider.from
             .withArgs(stubbedConfig.apiRoot, stubbedConfig.appId, stubbedConfig.appSecret)
             .resolves(stubbedProviderInstance);

--- a/src/commands/show-commands/balance.js
+++ b/src/commands/show-commands/balance.js
@@ -12,7 +12,8 @@ module.exports = {
         const provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
 
         try {
-            const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+            const privateKey = await config.privateKey(config.wallet.secret);
+            const wallet = new nahmii.Wallet(privateKey, provider);
             const balances = await wallet.getNahmiiBalance();
             console.log(JSON.stringify(balances));
         }

--- a/src/commands/stage.js
+++ b/src/commands/stage.js
@@ -37,7 +37,8 @@ module.exports = {
             const price = utils.parsePositiveInteger(argv.price);
             const gasPrice = ethers.utils.bigNumberify(price).mul(ethers.utils.bigNumberify(10).pow(9));
             
-            const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+            const privateKey = await config.privateKey(config.wallet.secret);
+            const wallet = new nahmii.Wallet(privateKey, provider);
             const settlement = new nahmii.SettlementFactory(provider);
             spinner.start('Staging qualified settlement(s)');
             

--- a/src/commands/stage.spec.js
+++ b/src/commands/stage.spec.js
@@ -116,7 +116,7 @@ describe('stage command', () => {
     beforeEach(() => {
         stubbedConfig.privateKey
             .withArgs(stubbedConfig.wallet.secret)
-            .returns('privatekey');
+            .resolves('privatekey');
         fakeNahmiiProvider.from
             .withArgs(stubbedConfig.apiRoot, stubbedConfig.appId, stubbedConfig.appSecret)
             .resolves(stubbedProviderInstance);

--- a/src/commands/unstage.js
+++ b/src/commands/unstage.js
@@ -38,7 +38,8 @@ module.exports = {
             const gasLimit = utils.parsePositiveInteger(argv.gas);
             const gasPriceInGwei = utils.parsePositiveInteger(argv.price);
             const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));
-            const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+            const privateKey = await config.privateKey(config.wallet.secret);
+            const wallet = new nahmii.Wallet(privateKey, provider);
 
             const unstageMonetaryAmount = nahmii.MonetaryAmount.from(amount, tokenInfo.currency);
             const stagedBalanceBN = await wallet.getNahmiiStagedBalance(tokenInfo.symbol);

--- a/src/commands/unstage.spec.js
+++ b/src/commands/unstage.spec.js
@@ -90,7 +90,7 @@ describe('Unstage command', () => {
     beforeEach(() => {
         stubbedConfig.privateKey
             .withArgs(stubbedConfig.wallet.secret)
-            .returns('privatekey');
+            .resolves('privatekey');
         fakeNahmiiProvider.from
             .withArgs(stubbedConfig.apiRoot, stubbedConfig.appId, stubbedConfig.appSecret)
             .resolves(stubbedProviderInstance);

--- a/src/commands/withdraw.js
+++ b/src/commands/withdraw.js
@@ -35,7 +35,8 @@ module.exports = {
         const gasPriceInGwei = utils.parsePositiveInteger(argv.price);
         const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));
 
-        const wallet = new nahmii.Wallet(config.privateKey(config.wallet.secret), provider);
+        const privateKey = await config.privateKey(config.wallet.secret);
+        const wallet = new nahmii.Wallet(privateKey, provider);
 
         const spinner = ora();
         try {

--- a/src/commands/withdraw.spec.js
+++ b/src/commands/withdraw.spec.js
@@ -90,7 +90,7 @@ describe('Withdraw command', () => {
     beforeEach(() => {
         stubbedConfig.privateKey
             .withArgs(stubbedConfig.wallet.secret)
-            .returns('privatekey');
+            .resolves('privatekey');
         fakeNahmiiProvider.from
             .withArgs(stubbedConfig.apiRoot, stubbedConfig.appId, stubbedConfig.appSecret)
             .resolves(stubbedProviderInstance);

--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,12 @@ if (!cfg) {
 cfg.file = configPath;
 
 cfg.privateKey = async (secret) => {
-    const keystore = fs.readFileSync(path.join(homedir, '.nahmii', 'keystore', cfg.wallet.address));
+    var files = fs.readdirSync(path.join(homedir, '.nahmii', 'keystore'));
+    const matchedFile = files.filter(f => f.toLowerCase().endsWith(cfg.wallet.address.toLowerCase()))[0];
+    if (!matchedFile) 
+        throw new Error(`keystore file for wallet ${cfg.wallet.address} not exists.`);
+    
+    const keystore = fs.readFileSync(path.join(homedir, '.nahmii', 'keystore', matchedFile));
     const wallet = await ethers.Wallet.fromEncryptedJson(keystore, secret);
     return wallet.privateKey;
 };

--- a/src/config.js
+++ b/src/config.js
@@ -2,11 +2,10 @@
 
 const path = require('path');
 const fs = require('fs');
+const ethers = require('ethers');
 const yaml = require('node-yaml');
 const {JSON_SCHEMA} = require('js-yaml');
-const keythereum = require('keythereum');
 const homedir = require('os').homedir();
-const {prefix0x} = require('nahmii-sdk').utils;
 
 const configPath = path.resolve(homedir, '.nahmii/config.yaml');
 if (!fs.existsSync(configPath)) {
@@ -25,10 +24,10 @@ if (!cfg) {
 }
 cfg.file = configPath;
 
-cfg.privateKey = (secret) => {
-//    console.debug(`Using key '${cfg.wallet.address}' for signing.`);
-    const keyObject = keythereum.importFromFile(cfg.wallet.address, path.resolve(homedir, '.nahmii'));
-    return prefix0x(keythereum.recover(secret, keyObject).toString('hex'));
+cfg.privateKey = async (secret) => {
+    const keystore = fs.readFileSync(path.join(homedir, '.nahmii', 'keystore', cfg.wallet.address));
+    const wallet = await ethers.Wallet.fromEncryptedJson(keystore, secret);
+    return wallet.privateKey;
 };
 
 module.exports = cfg;

--- a/src/config.js
+++ b/src/config.js
@@ -25,10 +25,11 @@ if (!cfg) {
 cfg.file = configPath;
 
 cfg.privateKey = async (secret) => {
-    var files = fs.readdirSync(path.join(homedir, '.nahmii', 'keystore'));
-    const matchedFile = files.filter(f => f.toLowerCase().endsWith(cfg.wallet.address.toLowerCase()))[0];
+    const files = fs.readdirSync(path.join(homedir, '.nahmii', 'keystore'));
+    const regex = new RegExp(cfg.wallet.address.replace('0x', ''), 'i');
+    const matchedFile = files.filter(f => f.match(regex)).shift();
     if (!matchedFile) 
-        throw new Error(`keystore file for wallet ${cfg.wallet.address} not exists.`);
+        throw new Error(`Unable to find keystore file for wallet ${cfg.wallet.address}`);
     
     const keystore = fs.readFileSync(path.join(homedir, '.nahmii', 'keystore', matchedFile));
     const wallet = await ethers.Wallet.fromEncryptedJson(keystore, secret);


### PR DESCRIPTION
When trying to install the CLI on node version 12, it throws errors indicating the `scrypt` dependency is not compatible with the version of nodejs.

`scrypt` is a dependency of `keythereum` module, which is to import keystore wallets. In fact, `scrypt` is deprecated and no longer maintained while `keythereum` hasn't been active to update itself to be compatible with node 12. 

Thus we are going to deprecate `keythereum` and prefer using the keystore import API of the existing dependency `ethers`.