### PR TITLE
Feature/settle 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-cli",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "CLI interface for using the nahmii by hubii protocol",
   "main": "index.js",
   "scripts": {

--- a/src/commands/settle.js
+++ b/src/commands/settle.js
@@ -12,7 +12,7 @@ module.exports = {
     builder: yargs => {
         yargs.example('settle 1 ETH', 'Start settlement(s) for 1 Ether using default gas limit and price.');
         yargs.example('settle 1 ETH --gas=500000', 'Start settlement(s) for 1 Ether and sets gas limit to 500000 while using default gas price.');
-        yargs.example('settle 1 ETH --price=2', 'Start settlement(s) for 1 Ether and sets gas price to 2 Gwei while using default gas limit.');
+        yargs.example('settle 0 ETH --price=2', 'Start settlement(s) for 0 Ether and sets gas price to 2 Gwei while using default gas limit.');
         yargs.example('settle 1000 HBT', 'Start settlement(s) for 1000 Hubiits (HBT) using default gas limit and price.');
         yargs.option('gas', {
             desc: 'Gas limit used _per transaction_. Settles can be 1 or more transactions depending on the stage amount.',

--- a/src/commands/settle.js
+++ b/src/commands/settle.js
@@ -36,6 +36,9 @@ module.exports = {
             provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
             const tokenInfo = await provider.getTokenInfo(currency);
             const amount = utils.parseAmount(argv.amount, tokenInfo.decimals);
+            if (!amount.gte(0))
+                throw new Error('Amount must be greater than zero!');
+
             const gasLimit = utils.parsePositiveInteger(argv.gas);
             const gasPriceInGwei = utils.parsePositiveInteger(argv.price);
             const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));

--- a/src/commands/settle.spec.js
+++ b/src/commands/settle.spec.js
@@ -353,4 +353,21 @@ describe('settle command', () => {
                 });
         });
     });
+
+    context('settle -1 ETH', () => {
+        it('yields an error', (done) => {
+            settleCmd.handler
+                .call(undefined, {
+                    amount: '-1',
+                    currency: 'ETH',
+                    gas: 2,
+                    price: 2
+                })
+                .catch(err => {
+                    expect(err.message).to.match(/amount.*greater than zero/i);
+                    done();
+                });
+        });
+    });
+
 });

--- a/src/commands/settle.spec.js
+++ b/src/commands/settle.spec.js
@@ -196,6 +196,52 @@ describe('settle command', () => {
         });
     });
 
+    context('settle 0 ETH', () => {
+        beforeEach(() => {
+            requiredSettlements = [
+                {
+                    type: 'payment',
+                    stageAmount: ethers.utils.parseUnits('1.0', 18),
+                    currency,
+                    start: sinon.stub().resolves(txRequest1),
+                    stage: sinon.stub()
+                },
+                {
+                    type: 'onchain-balance',
+                    stageAmount: ethers.utils.parseUnits('0.1', 18),
+                    currency,
+                    start: sinon.stub().resolves(txRequest2),
+                    stage: sinon.stub()
+                }
+            ];
+            stubbedSettlementFactory.getAllSettlements.resolves([]);
+            stubbedSettlementFactory.calculateRequiredSettlements.resolves(requiredSettlements);
+            return settleCmd.handler.call(undefined, {
+                amount: '0',
+                currency: 'ETH',
+                gas: 2,
+                price: 2
+            });
+        });
+
+        it('starts required settlements', () => {
+            for(const requiredSettlement of requiredSettlements) {
+                expect(requiredSettlement.start).to.have.been.calledWith(
+                    stubbedWallet,
+                    {
+                        gasLimit: 2,
+                        gasPrice: ethers.utils.bigNumberify(2000000000)
+                    }
+                );
+            }
+        });
+
+        it('stops token refresh/spinner', () => {
+            expect(stubbedOra.stop).to.have.been.called;
+            expect(stubbedProviderInstance.stopUpdate).to.have.been.called;
+        });
+    });
+
     context('no valid settlements to start with', () => {
         beforeEach(async () => {
             stubbedSettlementFactory.getAllSettlements.resolves([]);
@@ -303,22 +349,6 @@ describe('settle command', () => {
                 })
                 .catch(err => {
                     expect(err.message).to.match(/amount.*number/i);
-                    done();
-                });
-        });
-    });
-
-    context('settle 0 ETH', () => {
-        it('yields an error', (done) => {
-            settleCmd.handler
-                .call(undefined, {
-                    amount: '0',
-                    currency: 'ETH',
-                    gas: 2,
-                    price: 2
-                })
-                .catch(err => {
-                    expect(err.message).to.match(/amount.*zero/i);
                     done();
                 });
         });

--- a/src/commands/unstage.js
+++ b/src/commands/unstage.js
@@ -35,8 +35,8 @@ module.exports = {
             const tokenInfo = await provider.getTokenInfo(argv.currency);
             
             const amount = utils.parseAmount(argv.amount, tokenInfo.decimals);
-            if (amount.eq(0))
-                throw new Error('Amount must be greater than zero!');
+            if (!amount.gt(0))
+                throw new Error('Amount must be strictly greater than zero!');
 
             const gasLimit = utils.parsePositiveInteger(argv.gas);
             const gasPriceInGwei = utils.parsePositiveInteger(argv.price);

--- a/src/commands/unstage.js
+++ b/src/commands/unstage.js
@@ -35,6 +35,9 @@ module.exports = {
             const tokenInfo = await provider.getTokenInfo(argv.currency);
             
             const amount = utils.parseAmount(argv.amount, tokenInfo.decimals);
+            if (amount.eq(0))
+                throw new Error('Amount must be greater than zero!');
+
             const gasLimit = utils.parsePositiveInteger(argv.gas);
             const gasPriceInGwei = utils.parsePositiveInteger(argv.price);
             const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));

--- a/src/commands/unstage.spec.js
+++ b/src/commands/unstage.spec.js
@@ -200,7 +200,23 @@ describe('Unstage command', () => {
                     gas: 2
                 })
                 .catch(err => {
-                    expect(err.message).to.match(/amount.*zero/i);
+                    expect(err.message).to.match(/amount.*strictly greater than zero/i);
+                    done();
+                });
+        });
+
+    });
+
+    context('unstage -1 ETH', () => {
+        it('yields an error', (done) => {
+            unstageCmd.handler
+                .call(undefined, {
+                    amount: '-1',
+                    currency: 'ETH',
+                    gas: 2
+                })
+                .catch(err => {
+                    expect(err.message).to.match(/amount.*strictly greater than zero/i);
                     done();
                 });
         });

--- a/src/commands/withdraw.js
+++ b/src/commands/withdraw.js
@@ -34,8 +34,8 @@ module.exports = {
             provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
             const tokenInfo = await provider.getTokenInfo(argv.currency);
             const amount = utils.parseAmount(argv.amount, tokenInfo.decimals);
-            if (amount.eq(0))
-                throw new Error('Amount must be greater than zero!');
+            if (!amount.gt(0))
+                throw new Error('Amount must be strictly greater than zero!');
 
             const gasLimit = utils.parsePositiveInteger(argv.gas);
             const gasPriceInGwei = utils.parsePositiveInteger(argv.price);

--- a/src/commands/withdraw.js
+++ b/src/commands/withdraw.js
@@ -28,18 +28,22 @@ module.exports = {
     handler: async (argv) => {
         const config = require('../config');
         
-        const provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
-        const tokenInfo = await provider.getTokenInfo(argv.currency);
-        const amount = utils.parseAmount(argv.amount, tokenInfo.decimals);
-        const gasLimit = utils.parsePositiveInteger(argv.gas);
-        const gasPriceInGwei = utils.parsePositiveInteger(argv.price);
-        const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));
-
-        const privateKey = await config.privateKey(config.wallet.secret);
-        const wallet = new nahmii.Wallet(privateKey, provider);
-
+        let provider;
         const spinner = ora();
         try {
+            provider = await nahmii.NahmiiProvider.from(config.apiRoot, config.appId, config.appSecret);
+            const tokenInfo = await provider.getTokenInfo(argv.currency);
+            const amount = utils.parseAmount(argv.amount, tokenInfo.decimals);
+            if (amount.eq(0))
+                throw new Error('Amount must be greater than zero!');
+
+            const gasLimit = utils.parsePositiveInteger(argv.gas);
+            const gasPriceInGwei = utils.parsePositiveInteger(argv.price);
+            const gasPrice = ethers.utils.bigNumberify(gasPriceInGwei).mul(ethers.utils.bigNumberify(10).pow(9));
+
+            const privateKey = await config.privateKey(config.wallet.secret);
+            const wallet = new nahmii.Wallet(privateKey, provider);
+
             const withdrawMonetaryAmount = nahmii.MonetaryAmount.from(amount, tokenInfo.currency);
             const stagedBalanceBN = await wallet.getNahmiiStagedBalance(tokenInfo.symbol);
             

--- a/src/commands/withdraw.spec.js
+++ b/src/commands/withdraw.spec.js
@@ -199,7 +199,22 @@ describe('Withdraw command', () => {
                     gas: 2
                 })
                 .catch(err => {
-                    expect(err.message).to.match(/amount.*zero/i);
+                    expect(err.message).to.match(/amount.*strictly greater than zero/i);
+                    done();
+                });
+        });
+    });
+
+    context('withdraw -1 ETH', () => {
+        it('yields an error', (done) => {
+            withdrawCmd.handler
+                .call(undefined, {
+                    amount: '0',
+                    currency: 'ETH',
+                    gas: 2
+                })
+                .catch(err => {
+                    expect(err.message).to.match(/amount.*strictly greater than zero/i);
                     done();
                 });
         });

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,9 +13,6 @@ function parseAmount(amount, decimals) {
         throw new TypeError('Amount must be a number!');
     }
 
-    if (amountBN.eq(0))
-        throw new Error('Amount must be greater than zero!');
-
     return amountBN;
 }
 


### PR DESCRIPTION
### Purpose
This PR enables the start of settlements with stage amount value of 0. This enables the settlement for wallets that have 0 active balance and still should settle for the staging of accrued.

### Changes
* Update `src/commands/settle.js` to support the start of settlement of amount of 0
* Move test on 0 amount out of `parseAmount()` and into `src/commands/unstage.js` and `src/commands/withdraw.js`.

### Issues
* #103 

### Checklist
_Please check if your PR fulfills the following requirements:_
- [x] Associated issue has been created and referenced above
- [x] Package version number has been updated according to semantic rules
- [x] Tests for the changes have been added and all test pass (`npm test`)
- [x] Test coverage requirements have been met or improved (`.nycrc`)
- [x] Eslint has been run and reported issues have been fixed (`npm run eslint`)
- [ ] Codeclimate has been run and reported issues have been fixed (`npm run codeclimate`)
