### PR TITLE
Update patch with local execution of npm publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ typings/
 
 # IDEs
 .idea
+*.iml
 .vscode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahmii-cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CLI interface for using the nahmii by hubii protocol",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
The npm packages with versions `1.2.4` and `1.3.0` are broken and do not allow for local installation with `npm install nahmii-cli`. An npm package was built locally and published, triggering the bump of the version patch.

### Changes
<!-- A list of changes that are maid to achieve the purpose.  -->

### Issues
<!-- A list of issues addressed in this pull request. Consider to create a new issue if no relevant issue already exists.  -->

### Checklist
_Please check if your PR fulfils the following requirements:_
- [ ] Associated issue has been created and referenced above
- [x] Package version number has been updated according to semantic rules
- [x] Added unit tests for the changes and all tests pass (`npm test`)
- [ ] Added acceptance tests for new features and all tests pass (`npm run acceptance:test`)
- [ ] Test coverage requirements have been met or improved (`.nycrc`)
- [ ] Eslint has been run and reported issues have been fixed (`npm run lint`)
- [ ] Codeclimate has been run and reported issues have been fixed (`npm run codeclimate`)
